### PR TITLE
Experimental replacement for tig

### DIFF
--- a/tilde/exe/gb
+++ b/tilde/exe/gb
@@ -9,8 +9,16 @@ set -l DATE "%(color:green)(%(committerdate:relative))%(color:reset)"
 set -l AUTHOR "%(color:blue)%(color:bold)<%(authorname)>%(color:reset)"
 set -l CONTENTS "%(contents:subject)"
 
-# { as separator, because it is rare
-set -l FORMAT "$PREFIX{$REF{$HASH{$DATE{$AUTHOR{$CONTENTS"
+set -l FORMAT "$PREFIX $REF $HASH $DATE $AUTHOR $CONTENTS"
+
+# set -l extract_branch "sed 's/^*//' | awk '{print \$1;}'"
+
+set -l enter_cmd "echo {} | git switch (sed 's/^*//' | awk '{print \$1;}')"
+
+set -l opts "
+  --ansi
+  --bind=\"enter:execute($enter_cmd)+accept\"
+"
 
 git branch -v --color=always --format="$FORMAT" $argv |
-column -t -s '{'
+  FZF_DEFAULT_OPTS="$opts" fzf

--- a/tilde/exe/tiggy
+++ b/tilde/exe/tiggy
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# a tiny tig replacement, shamelessly ripped of from
+# https://github.com/wfxr/forgit/blob/master/bin/git-forgit
+
+files=$(sed -nE 's/.*-- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
+
+extract_sha="grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]'"
+
+preview_context=-3
+
+preview_cmd="echo {} | $extract_sha | xargs -I% git show --color=always -U$preview_context % -- $files | cat"
+
+enter_cmd="echo {} | $extract_sha | xargs -I% ${FORGIT} diff %^! $files"
+
+opts="
+  --ansi
+  --height='80%'
+  --bind='alt-k:preview-up,alt-p:preview-up'
+  --bind='alt-j:preview-down,alt-n:preview-down'
+  --bind='ctrl-r:toggle-all'
+  --bind='ctrl-s:toggle-sort'
+  --bind='?:toggle-preview'
+  --bind='alt-w:toggle-preview-wrap'
+  --preview-window='right:60%'
+  +1
+  +s +m --tiebreak=index
+  --bind=\"enter:execute($enter_cmd)\"
+  --bind=\"ctrl-y:execute-silent(echo {} | $extract_sha | ${FORGIT_COPY_CMD:-pbcopy})\"
+  --preview=\"$preview_cmd\"
+"
+
+log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
+
+eval "git log --graph --color=always --format='$log_format' $*" |
+    FZF_DEFAULT_OPTS="$opts" fzf
+
+# exit successfully on fzf exit code 130 (ctrl-c/esc)
+[[ $? == 130 ]] && exit 0


### PR DESCRIPTION
I came across [forgit](https://github.com/wfxr/forgit) and realized that fzf is more powerful than I thought. Here I am playing around with the code from forgit to replicate (and improve on) tig, but using fzf and not much more.

The preview window is the big thing here. You can scroll inside the preview with `shift+up` and `shift+down` – but this is configurable, and I probably need to find something better here. But when pressing enter, the diff for this commit is opened, which is likely the better way to look into the details anyway?

* [ ] Combine with the ideas of `gl`? Replace `gl`?